### PR TITLE
Upgrade Play in Docker to Play Framework version 2.7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,13 @@
 FROM openjdk:12-alpine AS build
 
 # Establish preliminary environment variables
+ARG PLAY_VERSION
+ARG SCALA_VERSION
+ARG SBT_VERSION
+
 ENV \
     SBT_HOME="/opt/sbt" \
-    SBT_VERSION="1.2.8" \
-    PLAY_VERSION="2.7.3" \
-    SCALA_VERSION="2.13.0" \
+    SBT_VERSION="${SBT_VERSION}" \
     PATH="${PATH}:/opt/sbt/bin"
 
 # Install necessary build tools & install SBT v1.2.8
@@ -33,18 +35,24 @@ RUN cd /tmp/build && \
 # ---------------------------------------------------------------------------
 FROM alpine:latest
 
+ARG PLAY_VERSION
+ARG SCALA_VERSION
+
 LABEL name="Play in Docker" \
       maintainer="James Coon <james@jcoon.dev>" \
       version="Play Framework v${PLAY_VERSION}" \
       homepage="https://github.com/BuiltInCode/play-in-docker"
 
+ENV PLAY_VERSION="${PLAY_VERSION}"
+ENV SCALA_VERSION="${SCALA_VERSION}"
 ENV PATH="${PATH}:/opt/openjdk-12/bin:/opt/sbt/bin"
 
 COPY --from=build /opt /opt
 COPY --from=build /root/.ivy2 /root/.ivy2
 COPY --from=build /root/.sbt /root/.sbt
 
-RUN mkdir -p /app
+RUN apk add bash && \
+    mkdir -p /app
 
 WORKDIR /app
 EXPOSE 9000

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN cd /tmp/build && \
 # ------------------------------ BUILD TWO (2) ------------------------------
 # Using our previous build as a "base," create a new alpine Linux container
 # and copy ("extract") all of our built dependencies, such as OpenJDK and
-# SBT over to the new project.
+# SBT over to the new project, as well as SBT app/build dependencies
 #
 # Once that is finished, then install bash for SBT and configure our project
 # ---------------------------------------------------------------------------
@@ -35,17 +35,18 @@ FROM alpine:latest
 
 LABEL name="Play in Docker" \
       maintainer="James Coon <james@jcoon.dev>" \
-      version="Play Framework v2.7.3" \
+      version="Play Framework v${PLAY_VERSION}" \
       homepage="https://github.com/BuiltInCode/play-in-docker"
 
 ENV PATH="${PATH}:/opt/openjdk-12/bin:/opt/sbt/bin"
 
 COPY --from=build /opt /opt
-RUN apk add --no-cache bash
+COPY --from=build /root/.ivy2 /root/.ivy2
+COPY --from=build /root/.sbt /root/.sbt
+
 RUN mkdir -p /app
 
 WORKDIR /app
 EXPOSE 9000
 
-ENTRYPOINT ["sbt"]
-CMD ["run"]
+CMD ["sbt", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM openjdk:12-alpine
-MAINTAINER James Coon <james@jcoon.dev>
+# ------------------------------ BUILD ONE (1) ------------------------------
+# Build all of the necessary tools and verify that our Play Framework
+# application is configured and works correctly with the most recent version
+# ---------------------------------------------------------------------------
+FROM openjdk:12-alpine AS build
 
-# Establish preliminary path variables
+# Establish preliminary environment variables
 ENV \
     SBT_HOME="/opt/sbt" \
     SBT_VERSION="1.2.8" \
@@ -10,8 +13,7 @@ ENV \
     PATH="${PATH}:/opt/sbt/bin"
 
 # Install necessary build tools & install SBT v1.2.8
-RUN apk add --no-cache --virtual=.build-deps ca-certificates tar wget && \
-    apk add --no-cache bash curl jq && \
+RUN apk add --no-cache bash ca-certificates curl jq tar wget && \
     mkdir -p ${SBT_HOME} && \
     wget -qO - --no-check-certificate "https://piccolo.link/sbt-${SBT_VERSION}.tgz" | tar xz -C ${SBT_HOME} --strip-components=1
 
@@ -22,12 +24,28 @@ RUN cd /tmp/build && \
     sbt ++${SCALA_VERSION}! compile && \
     rm -rf /tmp/
 
-# Finally, remove our build dependencies
-RUN apk del .build-deps
+# ------------------------------ BUILD TWO (2) ------------------------------
+# Using our previous build as a "base," create a new alpine Linux container
+# and copy ("extract") all of our built dependencies, such as OpenJDK and
+# SBT over to the new project.
+#
+# Once that is finished, then install bash for SBT and configure our project
+# ---------------------------------------------------------------------------
+FROM alpine:latest
 
-# Set up Play! Framework directory and ports
+LABEL name="Play in Docker" \
+      maintainer="James Coon <james@jcoon.dev>" \
+      version="Play Framework v2.7.3" \
+      homepage="https://github.com/BuiltInCode/play-in-docker"
+
+ENV PATH="${PATH}:/opt/openjdk-12/bin:/opt/sbt/bin"
+
+COPY --from=build /opt /opt
+RUN apk add --no-cache bash
 RUN mkdir -p /app
+
 WORKDIR /app
 EXPOSE 9000
 
-CMD ["sbt", "run"]
+ENTRYPOINT ["sbt"]
+CMD ["run"]

--- a/src/build.sbt
+++ b/src/build.sbt
@@ -1,4 +1,5 @@
 name := """play-in-docker"""
+
 version := sys.env.get("PLAY_VERSION").get
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
@@ -6,3 +7,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayJava)
 scalaVersion := sys.env.get("SCALA_VERSION").get
 
 crossScalaVersions := Seq("2.12.8", sys.env.get("SCALA_VERSION").get)
+
+logLevel := Level.Error
+
+updateOptions := updateOptions.value.withCachedResolution(true)

--- a/src/build.sbt
+++ b/src/build.sbt
@@ -3,7 +3,7 @@ version := "2.7.2"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 javacOptions ++= Seq(
   "-encoding", "UTF-8",
@@ -13,7 +13,7 @@ javacOptions ++= Seq(
   "-Werror"
 )
 
-crossScalaVersions := Seq("2.11.12", "2.12.8")
+crossScalaVersions := Seq("2.11.12", "2.13.0")
 
 libraryDependencies ++= Seq(
   guice,

--- a/src/build.sbt
+++ b/src/build.sbt
@@ -1,25 +1,8 @@
-name := """docker-play"""
-version := "2.7.2"
+name := """play-in-docker"""
+version := sys.env.get("PLAY_VERSION").get
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala)
+lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.13.0"
+scalaVersion := sys.env.get("SCALA_VERSION").get
 
-javacOptions ++= Seq(
-  "-encoding", "UTF-8",
-  "-parameters",
-  "-Xlint:unchecked",
-  "-Xlint:deprecation",
-  "-Werror"
-)
-
-crossScalaVersions := Seq("2.11.12", "2.13.0")
-
-libraryDependencies ++= Seq(
-  guice,
-  "com.h2database" % "h2" % "1.4.199",
-  "org.assertj" % "assertj-core" % "3.11.1" % Test,
-  "org.awaitility" % "awaitility" % "3.1.3" % Test
-)
-
-testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
+crossScalaVersions := Seq("2.12.8", sys.env.get("SCALA_VERSION").get)

--- a/src/project/plugins.sbt
+++ b/src/project/plugins.sbt
@@ -1,1 +1,3 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.2")
+resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
+
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.env.get("PLAY_VERSION").get)

--- a/src/project/plugins.sbt
+++ b/src/project/plugins.sbt
@@ -1,2 +1,1 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.2")
-addSbtPlugin("com.typesafe.sbt" % "sbt-play-enhancer" % "1.2.2")


### PR DESCRIPTION
As written within `CHANGELOG.md`, the pull request contains the following changes:
* Re-wrote Dockerfile to use alpine-based images for better space conservation
* Implemented build arguments for faster upgrades/iterations in the future
* Upgraded Play Framework version to use v2.7.3
* Upgraded Java version to use OpenJDK 12 (alpine edition)
* Upgraded Scala version to use v2.13.0 (`Play Framework` was upgraded to use v2.13.0 in its 2.7.3 iteration)